### PR TITLE
feat(social-service): Añadir validaciones

### DIFF
--- a/backend/social-service/src/controllers/friend.controller.ts
+++ b/backend/social-service/src/controllers/friend.controller.ts
@@ -14,13 +14,16 @@ export const createFriendController = async (req: Request, res: Response): Promi
     res.status(201).json(newFriend); // Retornamos el nuevo amigo creado
 
   } catch (error) {
-    res.status(500).json({ message:'Error al crear amistad:', error });
+    res.status(500).json({ 
+      message: 'Error al crear amistad:', 
+      error: error instanceof Error ? error.message : error 
+    });
   }
 };
 
 export const listFriendsController = async (req: Request, res: Response): Promise<void> => {
   try {
-    const { status } = req.query; // Obtenemos el estado de la solicitud de amistad (PENDING/ACCEPTED)
+    const { status } = req.params; // Obtenemos el estado de la solicitud de amistad (PENDING/ACCEPTED)
     const { userId } = req.params; // Obtenemos el ID del usuario de la URL
 
     if (!status || !userId) {

--- a/backend/social-service/src/models/friend.model.ts
+++ b/backend/social-service/src/models/friend.model.ts
@@ -19,6 +19,7 @@ import {
   export enum FriendStatus {
     PENDING = 'PENDING',
     ACCEPTED = 'ACCEPTED',
+    BLOCKED = 'BLOCKED',	
   }
   
   @Entity('friend')

--- a/backend/social-service/src/services/friend.service.ts
+++ b/backend/social-service/src/services/friend.service.ts
@@ -1,39 +1,68 @@
 /**
- * Servicio de Distritos
- * Gestiona la creación, consulta y desbloqueo de distritos del mapa
+ * Servicio de Amigos
+ * Gestiona la creación, consulta, actualización y 
+ * eliminación de solicitudes y relaciones de amistad entre usuarios.
  */
 
-//import { publishEvent } from '@shared/libs/rabbitmq';
 import { Friend, FriendStatus } from '../models/friend.model';
-import { AppDataSource } from '../../../database/appDataSource';
 import FriendRepository from '../repositories/friend.repository';
 import { User } from '../../../auth-service/src/models/user.model';
+import { AppDataSource } from '../../../database/appDataSource';
 
 const repo = new FriendRepository();
 
-
-
+/**
+ * Crea una nueva solicitud de amistad.
+ * Valida que se proporcionen los datos obligatorios: receptor, solicitante y estado de la solicitud.
+ *
+ * @param friendData Datos de la solicitud de amistad (excluyendo el ID)
+ * @returns La solicitud de amistad creada
+ */
 export const createFriend = async (
-  friendData: Omit<Friend, 'id'>,
+  friendData: Omit<Friend, 'id'>
 ): Promise<Friend> => {
-
   try {
     if (!friendData.recipient || !friendData.requester || !friendData.status) {
-      throw new Error("Los datos de receptor, solicitante y estado de la petición son necesarios.")
-    }  
-    const newFriend = repo.createFriend(friendData);
-    console.log("Entrada de solicitud de amistad realizada", newFriend);
-    return newFriend;
+      throw new Error("Los datos de receptor, solicitante y estado de la petición son necesarios.");
+    }
 
+    const requesterId = typeof friendData.requester === 'string' ? friendData.requester : friendData.requester.id;
+    const recipientId = typeof friendData.recipient === 'string' ? friendData.recipient : friendData.recipient.id;
+
+    if (requesterId === recipientId) {
+      throw new Error("El receptor y el solicitante deben ser distintos.");
+    }
+
+    const userRepository = AppDataSource.getRepository(User);
+
+    const requester = await userRepository.findOne({ where: { id: requesterId } });
+    if (!requester) {
+      throw new Error(`Usuario solicitante con ID ${requesterId} no encontrado`);
+    }
+
+    const recipient = await userRepository.findOne({ where: { id: recipientId } });
+    if (!recipient) {
+      throw new Error(`Usuario receptor con ID ${recipientId} no encontrado`);
+    }
+
+    const newFriend = repo.createFriend(friendData);
+    console.log("Solicitud de amistad creada:", newFriend);
+    return newFriend;
   } catch (error) {
-    console.log(error)
+    console.log(error);
+    throw error;
   }
-  throw new Error('Método no implementado');
 };
 
-
+/**
+ * Lista las solicitudes de amistad de un usuario según el estado indicado.
+ *
+ * @param status Estado de la solicitud de amistad (PENDING, ACCEPTED, BLOCKED)
+ * @param userId ID del usuario
+ * @returns Lista de solicitudes de amistad
+ */
 export const listFriends = async (
-  status:FriendStatus,
+  status: FriendStatus,
   userId: string
 ): Promise<Friend[]> => {
   const friends = await repo.findAllByIdAndStatus(userId, status);
@@ -41,45 +70,41 @@ export const listFriends = async (
     throw new Error(`No se encontraron solicitudes de amistad para el usuario con ID ${userId}`);
   }
   return friends;
-
-};
-
- 
-
-export const findFriendById = async (friendId: string): Promise<Friend | null> => {
-  // TODO: Implementar la obtención de un distrito por ID
-  // 1. Buscar el distrito en la base de datos
-  const friend = await repo.getFriendById(friendId);
-
-
-  // 2. Retornar null si no se encuentra
-  if (friend === null) {
-    throw new Error(`Distrito con ID ${friendId} no encontrado`);
-  }
-  else {
-    return friend;
-  }
-
 };
 
 /**
- * Obtiene todos los distritos
- * @param includeInactive Indica si se deben incluir distritos inactivos
+ * Obtiene una solicitud de amistad por su ID.
+ *
+ * @param friendId ID de la solicitud de amistad
+ * @returns La solicitud de amistad encontrada o lanza un error si no existe
+ */
+export const findFriendById = async (friendId: string): Promise<Friend | null> => {
+  const friend = await repo.getFriendById(friendId);
+  if (friend === null) {
+    throw new Error(`Solicitud de amistad con ID ${friendId} no encontrada`);
+  } else {
+    return friend;
+  }
+};
+
+/**
+ * Busca usuarios por nombre para facilitar la selección de amigos.
+ *
+ * @param nameData Texto de búsqueda del nombre del usuario
+ * @returns Lista de usuarios que coinciden con el criterio de búsqueda
  */
 export const listSearchUser = async (
   nameData: string
 ): Promise<User[]> => {
-  // TODO: Implementar la obtención de todos los distritos
-  // 1. Consultar todos los distritos en la base de datos
   const users = await repo.findAllUsersByName(nameData);
   return users;
 };
 
 /**
- * Actualiza un distrito existente
- * @param districtId ID del distrito a actualizar
- * @param updateData Datos a actualizar del distrito
- * @param userId ID del usuario administrador que realiza la actualización
+ * Actualiza el estado de una solicitud de amistad.
+ *
+ * @param friendId ID de la solicitud de amistad a actualizar
+ * @returns Objeto con el resultado de la actualización
  */
 export const updateFriendStatus = async (
   friendId: string,
@@ -87,18 +112,19 @@ export const updateFriendStatus = async (
   success: boolean;
   message?: string;
 }> => {
-
   const updatedFriend = await repo.updateFriendStatus(friendId);
-  // 3. Publicar evento de distrito desbloqueado
   if (updatedFriend.status === FriendStatus.ACCEPTED) {
     return { success: true, message: 'Solicitud de amistad aceptada correctamente' };
   } else {
-    throw new Error('Error al aceptar la solicitud de amistad');
+    throw new Error('Error al actualizar el estado de la solicitud de amistad');
   }
-
 };
 
+/**
+ * Elimina una solicitud de amistad.
+ *
+ * @param friendId ID de la solicitud de amistad a eliminar
+ */
 export const deleteFriend = async (friendId: string): Promise<void> => {
   await repo.deleteFriend(friendId);
 };
-


### PR DESCRIPTION
Se ha revisado y añadido validaciones en los datos acorde al documento de requisitos

- Se ha actualizado el enum FriendStatus para incluir el estado BLOCKED

- Se ha incluido una validación que impide que el solicitante y el receptor sean el mismo usuario, extrayendo el ID.

- Se implementó la verificación en la base de datos), para comprobar que tanto el usuario solicitante como el receptor existen antes de crear la solicitud de amistad.

- Se corrigió el controlador de listado para obtener el parámetro status desde req.params (en lugar de req.query),para que coincida con la definición de rutas.

- Se han modificado las firmas de los métodos que incluian referencias a Distritos