### PR TITLE
Feature/backend designar colores mapas colaborativos

### DIFF
--- a/backend/map-service/src/models/user-district.model.ts
+++ b/backend/map-service/src/models/user-district.model.ts
@@ -1,16 +1,23 @@
-import { Entity, PrimaryGeneratedColumn, Column, CreateDateColumn, UpdateDateColumn, ManyToOne, OneToMany, RelationId, JoinColumn } from 'typeorm';
-import { Geometry } from 'geojson';
-import { Map } from './map.model';
+import { Entity, PrimaryGeneratedColumn, Column, ManyToOne, JoinColumn } from 'typeorm';
 import { User } from '../../../auth-service/src/models/user.model';
 import { District } from './district.model';
+
+export enum Color {
+    AZUL = '#0000FF',
+    VERDE = '#00FF00',
+    AMARILLO = '#FFFF00',
+    NARANJA = '#FFA500',
+    FUCSIA = '#FF00FF',
+    MORADO = '#800080'
+  }
 
 @Entity('user-district')
 export class UserDistrict {
     @PrimaryGeneratedColumn('uuid')
     id!: string;
 
-    @Column({ type: 'varchar', length: 255, nullable: false })
-    color!: string;
+    @Column({ type: 'enum', enum: Color, default: Color.VERDE })
+    color!: Color;
 
     @ManyToOne(() => User, (user) => user.userDistrict)
     @JoinColumn({ name: 'UsuarioColoreador' })

--- a/backend/map-service/src/repositories/district.repository.ts
+++ b/backend/map-service/src/repositories/district.repository.ts
@@ -4,7 +4,7 @@ import { AppDataSource } from '../../../database/appDataSource'; // Importa la i
 import { Map } from '../models/map.model';
 import { Region } from '../models/region.model';
 import { User } from '../../../auth-service/src/models/user.model';
-import { UserDistrict } from '../models/user-district.model';
+import { Color, UserDistrict } from '../models/user-district.model';
 
 export default class DistrictRepository {
     private districtRepo: Repository<District>;
@@ -76,7 +76,7 @@ export default class DistrictRepository {
             const userDistrict = new UserDistrict();
             userDistrict.user = discoveredBy;
             userDistrict.district = district;
-            userDistrict.color = '#000000'; // Poner los colores definidos
+            userDistrict.color = Color.AZUL; // Poner los colores definidos(Los colores definidos son los posibles valores del enum Color)
             await this.userDistrictRepo.save(userDistrict);
         }
         return await this.districtRepo.save(district);

--- a/backend/map-service/src/repositories/user-district.repository.ts
+++ b/backend/map-service/src/repositories/user-district.repository.ts
@@ -1,6 +1,6 @@
 import { Repository } from 'typeorm';
 import { AppDataSource } from '../../../database/appDataSource';
-import { UserDistrict } from '../models/user-district.model';
+import { Color, UserDistrict } from '../models/user-district.model';
 import { District } from '../models/district.model';
 
 export class UserDistrictRepository {
@@ -35,7 +35,7 @@ export class UserDistrictRepository {
         }
     }
 
-    async assignColorToUserDistrict(userId: string, districtId: string, color: string): Promise<UserDistrict> {
+    async assignColorToUserDistrict(userId: string, districtId: string, color: Color): Promise<UserDistrict> {
         try {
             // Buscar si ya existe una asignación
             let userDistrict = await this.repo.createQueryBuilder("userDistrict")

--- a/backend/map-service/src/services/district.service.ts
+++ b/backend/map-service/src/services/district.service.ts
@@ -12,7 +12,7 @@ import MapRepository from '../repositories/map.repository';
 import * as fs from 'fs';
 import { Geometry } from 'geojson';
 import { AuthRepository } from '../../../auth-service/src/repositories/auth.repository';
-import { UserDistrict } from '../models/user-district.model';
+import { Color, UserDistrict } from '../models/user-district.model';
 import RegionRepository from '../repositories/region.repository';
 
 const filePath = 'database/map.geojson';
@@ -320,7 +320,7 @@ export const unlockCollaborativeDistrict = async (
 
     // Crear un objeto UserDistrict que cumpla con el modelo actualizado
     const userdistrict = {
-      color: "pepe",
+      color: Color.AZUL,
       user: user,
       district: district
     };
@@ -353,7 +353,7 @@ export const unlockCollaborativeDistrict = async (
 export const simulateUserPassingByDistrict = async (
   userId: string,
   districtId: string,
-  color: string = "pepe", // Valor por defecto
+  color: Color = Color.AZUL, // Valor por defecto
   mapId?: string // Opcional: ID del mapa colaborativo
 ): Promise<{
   success: boolean;

--- a/backend/payment-service/tests/subscription.test.ts
+++ b/backend/payment-service/tests/subscription.test.ts
@@ -43,6 +43,7 @@ const dummyUser: User = {
   receivedFriendRequests: [],
   maps_joined: [],
   subscription: {} as any,
+  userDistrict: [],
 };
 
 describe('Subscription Service', () => {


### PR DESCRIPTION
Se ha cambiado el atributo color de user-district para que sea un enumerado, tiene 6 posibles valores que coinciden con los colores que aparecen en el front.
Se han actualizado los servicios y el repositorio para mantener la consistencia de tipos.

Se ha modificado dummyUser para añadir el atributo userDisstrict y que los tests se ejecuten correctamente.