### PR TITLE
fix: Cambiar rutas achievements

### DIFF
--- a/backend/achievement-service/controllers/achievement.controller.ts
+++ b/backend/achievement-service/controllers/achievement.controller.ts
@@ -31,7 +31,7 @@ export const getAchievements = async (req: Request, res: Response, next: NextFun
 
 /**
  * Obtiene un logro por nombre
- * GET /achievements/name/:name
+ * GET /achievements/:achievementName
  */
 export const getAchievementByName = async (req: Request, res: Response, next: NextFunction) => {
   try {

--- a/backend/achievement-service/routes/achievement.routes.ts
+++ b/backend/achievement-service/routes/achievement.routes.ts
@@ -8,25 +8,25 @@ const router: Router = Router();
  * Crea un nuevo logro.
  * POST /achievements
  */
-router.post('/achievements', achievementController.createAchievement);
+router.post('/', achievementController.createAchievement);
 
 /**
  * Obtiene todos los logros.
  * GET /achievements
  */
-router.get('/achievements', achievementController.getAchievements);
+router.get('/', achievementController.getAchievements);
 
 /**
  * Obtiene un logro según su nombre.
  * GET /achievements/name/:name
  */
-router.get('/achievements/name/:name', achievementController.getAchievementByName);
+router.get('/name/:name', achievementController.getAchievementByName);
 
 /**
  * Obtiene un logro según su id.
  * GET /achievements/:id
  */
-router.get('/achievements/:id', achievementController.getAchievementById);
+router.get('/:id', achievementController.getAchievementById);
 
 
 export default router;

--- a/backend/achievement-service/routes/achievement.routes.ts
+++ b/backend/achievement-service/routes/achievement.routes.ts
@@ -18,9 +18,9 @@ router.get('/', achievementController.getAchievements);
 
 /**
  * Obtiene un logro según su nombre.
- * GET /achievements/name/:name
+ * GET /achievements/:achievementName
  */
-router.get('/name/:name', achievementController.getAchievementByName);
+router.get("/:achievementName", achievementController.getAchievementByName);
 
 /**
  * Obtiene un logro según su id.

--- a/backend/achievement-service/routes/userAchievement.routes.ts
+++ b/backend/achievement-service/routes/userAchievement.routes.ts
@@ -8,19 +8,19 @@ const router: Router = Router();
  * Crea un nuevo usuario-logro (desbloquea un logro para un usuario)
  * POST /user-achievements
  */
-router.post('/user-achievements', userAchievementController.createAchievement);
+router.post('/', userAchievementController.createAchievement);
 
 /**
  * Obtiene todos los logros (UserAchievement) obtenidos por un usuario.
  * GET /user-achievements/user/:userId
  */
-router.get('/user-achievements/user/:userId', userAchievementController.getAchievementsByUser);
+router.get('/user/:userId', userAchievementController.getAchievementsByUser);
 
 /**
  * Obtiene todos los usuarios que han desbloqueado un logro específico.
  * GET /user-achievements/achievement/:achievementId
  */
-router.get('/user-achievements/achievement/:achievementId', userAchievementController.getUsersByAchievement);
+router.get('/achievement/:achievementId', userAchievementController.getUsersByAchievement);
 
 
 export default router;

--- a/frontend/mobile/src/components/Achievements/UserAchievementsScreen.tsx
+++ b/frontend/mobile/src/components/Achievements/UserAchievementsScreen.tsx
@@ -58,7 +58,7 @@ const UserAchievementsScreen = () => {
           return;
         }
         setLoading(true);
-        const response = await fetch(`${API_URL}/api/user-achievements/user-achievements/user/${user.id}`, {
+        const response = await fetch(`${API_URL}/api/user-achievements/user/${user.id}`, {
           method: "GET",
           headers: { "Content-Type": "application/json" },
         });
@@ -125,7 +125,7 @@ const UserAchievementsScreen = () => {
         iconUrl: achievementIcon || iconPlaceholder,
         points: achievementPoints,
       };      
-      const response = await fetch(`${API_URL}/api/achievements/achievements`, {
+      const response = await fetch(`${API_URL}/api/achievements`, {
         method: "POST",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify(achievementData),


### PR DESCRIPTION
Se han modificado las rutas de achievement y userAchievement que tenian el patron duplicado. Los fetch que utilizaban dichas rutas en frontend tambien se han visto modificados

end  #210